### PR TITLE
Local par indent, fix. issue [Status: Open. #32] 

### DIFF
--- a/src/bisect.typ
+++ b/src/bisect.typ
@@ -118,7 +118,7 @@
   let dest = if "dest" in fields { (fields.remove("dest"),) } else { () }
   let styles = if "styles" in fields { (fields.remove("styles"),) } else { () }
   // Construct the closure
-  let rebuild(inner) = {
+  let rebuild(inner, is_right: false) = {
     assert(inner != none, message: "Internal error: `rebuild` operating on " + repr(ct.func()) + " received `inner: none`")
     let inner = if splat-inner {
       (..inner,)

--- a/tests/issues/par-first-line-indent/test.typ
+++ b/tests/issues/par-first-line-indent/test.typ
@@ -1,0 +1,14 @@
+#import "/src/lib.typ" as meander
+
+#let current-par = par(first-line-indent: (amount:2em, all: true), justify: true)[#lorem(200)]
+
+#meander.reflow({
+    meander.container(width: 49%)
+    meander.container()
+    meander.pagebreak()
+   meander.container(width: 49%)
+    meander.container()
+    meander.content({
+        for i in range(4){current-par}
+    })
+})

--- a/tests/issues/par-hanging-indent/test.typ
+++ b/tests/issues/par-hanging-indent/test.typ
@@ -1,0 +1,14 @@
+#import "/src/lib.typ" as meander
+
+#let current-par = par(hanging-indent: 2em, justify: true)[#lorem(200)]
+
+#meander.reflow({
+    meander.container(width: 49%)
+    meander.container()
+    meander.pagebreak()
+   meander.container(width: 49%)
+    meander.container()
+    meander.content({
+        for i in range(4){current-par}
+    })
+})


### PR DESCRIPTION
- Added a small piece of code to bisect::Default-Rebuild to ensure that when rebuilding a field's right side, it handles paragraph indentation as best as possible.

- Created two test directories related to the resolved issue. par-first-line-indent
par-hanging-indent

This change does not resolve the situation where indents are defined globally (with set).