### PR TITLE
Local par indent correction

### DIFF
--- a/src/bisect.typ
+++ b/src/bisect.typ
@@ -118,7 +118,7 @@
   let dest = if "dest" in fields { (fields.remove("dest"),) } else { () }
   let styles = if "styles" in fields { (fields.remove("styles"),) } else { () }
   // Construct the closure
-  let rebuild(inner) = {
+  let rebuild(inner, is_right: false) = {
     assert(inner != none, message: "Internal error: `rebuild` operating on " + repr(ct.func()) + " received `inner: none`")
     let inner = if splat-inner {
       (..inner,)

--- a/src/bisect.typ
+++ b/src/bisect.typ
@@ -125,6 +125,25 @@
     } else {
       (inner,)
     }
+      // Edit the Fields if the rebuild inner is a "right rebuild" and a body.
+    let fields =  if is_right and inner-field == "body"{
+        // If there is an hanging indent, then add the indend to the first line indend.
+          if fields.keys().contains("hanging-indent"){
+              let indent = fields.hanging-indent
+              let tmp = fields
+              tmp.insert("first-line-indent", (amount: indent, all: true))
+              tmp
+              // If there is a first line indent, remove it. 
+          } else if fields.keys().contains("first-line-indent"){
+              let tmp= fields
+              let _ =tmp.remove("first-line-indent",default:none)
+              tmp
+          }else{
+              fields
+          }
+    }else{
+        fields
+    }
     let pos = (..dest, ..inner, ..number, ..styles, ..alignment)
     ct.func()(..fields, ..pos)
   }
@@ -604,7 +623,7 @@
       left
     }
     let right = if right == none { none } else {
-      rebuild(right)
+      rebuild(right,is_right:true)
     }
     (left, right)
   } else {

--- a/tests/issues/par-first-line-indent/test.typ
+++ b/tests/issues/par-first-line-indent/test.typ
@@ -3,6 +3,7 @@
 #let current-par = par(first-line-indent: (amount:2em, all: true), justify: true)[#lorem(200)]
 
 #meander.reflow({
+     meander.placed(center+horizon,box(width: 5cm,height: 5cm,fill:red))
     meander.container(width: 49%)
     meander.container()
     meander.pagebreak()

--- a/tests/issues/par-first-line-indent/test.typ
+++ b/tests/issues/par-first-line-indent/test.typ
@@ -1,0 +1,14 @@
+#import "/src/lib.typ" as meander
+
+#let current-par = par(first-line-indent: (amount:2em, all: true), justify: true)[#lorem(200)]
+
+#meander.reflow({
+    meander.container(width: 49%)
+    meander.container()
+    meander.pagebreak()
+   meander.container(width: 49%)
+    meander.container()
+    meander.content({
+        for i in range(4){current-par}
+    })
+})

--- a/tests/issues/par-hanging-indent/test.typ
+++ b/tests/issues/par-hanging-indent/test.typ
@@ -3,12 +3,13 @@
 #let current-par = par(hanging-indent: 2em, justify: true)[#lorem(200)]
 
 #meander.reflow({
-    meander.container(width: 49%)
-    meander.container()
-    meander.pagebreak()
-   meander.container(width: 49%)
-    meander.container()
-    meander.content({
-        for i in range(4){current-par}
-    })
+  meander.placed(center + horizon, box(width: 5cm, height: 5cm, fill: red))
+  meander.container(width: 49%)
+  meander.container()
+  meander.pagebreak()
+  meander.container(width: 49%)
+  meander.container()
+  meander.content({
+    for i in range(4) { current-par }
+  })
 })

--- a/tests/issues/par-hanging-indent/test.typ
+++ b/tests/issues/par-hanging-indent/test.typ
@@ -1,0 +1,14 @@
+#import "/src/lib.typ" as meander
+
+#let current-par = par(hanging-indent: 2em, justify: true)[#lorem(200)]
+
+#meander.reflow({
+    meander.container(width: 49%)
+    meander.container()
+    meander.pagebreak()
+   meander.container(width: 49%)
+    meander.container()
+    meander.content({
+        for i in range(4){current-par}
+    })
+})


### PR DESCRIPTION
- Added a small piece of code to bisect::Default-Rebuild to ensure that when rebuilding a field's right side, it handles paragraph indentation as best as possible. 

- Created two test directories related to the resolved issue. 
par-first-line-indent
par-hanging-indent

This change does not resolve the situation where indents are defined globally (with set).